### PR TITLE
Check for whether extension is loaded

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": "4.*",
-		  "ext-memcached": "*"
+        "ext-memcached": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.3.*",

--- a/src/Atyagi/Elasticache/ElasticacheConnector.php
+++ b/src/Atyagi/Elasticache/ElasticacheConnector.php
@@ -1,18 +1,20 @@
 <?php namespace Atyagi\Elasticache;
 
-use Memcached;
-
 class ElasticacheConnector {
 
     /**
      * Create a new Memcached connection.
      *
      * @param array $servers
+     * @return false|\Memcached
      * @throws \RuntimeException
-     * @return \Memcached
      */
     public function connect(array $servers)
     {
+        if (!extension_loaded('memcached')) {
+            return false;
+        }
+
         $memcached = $this->getMemcached();
 
         // Set Elasticache options here

--- a/src/Atyagi/Elasticache/ElasticacheServiceProvider.php
+++ b/src/Atyagi/Elasticache/ElasticacheServiceProvider.php
@@ -4,46 +4,50 @@ use Illuminate\Support\ServiceProvider;
 
 class ElasticacheServiceProvider extends ServiceProvider {
 
-	/**
-	 * Indicates if loading of the provider is deferred.
-	 *
-	 * @var bool
-	 */
-	protected $defer = false;
+    /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = false;
 
-	/**
-	 * Register the service provider.
-	 *
-	 * @return void
-	 */
-	public function register()
-	{
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
         $servers = $this->app['config']->get('cache.memcached');
         $elasticache = new ElasticacheConnector();
         $memcached = $elasticache->connect($servers);
 
-        $this->app->getProviderRepository()->load($this->app, array('Illuminate\Cache\CacheServiceProvider'));
+        // memcached extension not loaded
+        if (!$memcached) {
 
-        $this->app->make('session')->extend('elasticache', function() use ($memcached) {
-            return new ElasticacheSessionHandler($memcached, $this->app);
-        });
+            $this->app->getProviderRepository()->load($this->app, ['Illuminate\Cache\CacheServiceProvider']);
 
-        $this->app->make('cache')->extend('elasticache', function() use ($memcached) {
-            /** @noinspection PhpUndefinedNamespaceInspection */
-            /** @noinspection PhpUndefinedClassInspection */
-            return new \Illuminate\Cache\Repository(
-                new \Illuminate\Cache\MemcachedStore($memcached, $this->app['config']->get('cache.prefix')));
-        });
-	}
+            $this->app->make('session')->extend('elasticache', function () use ($memcached) {
+                return new ElasticacheSessionHandler($memcached, $this->app);
+            });
 
-	/**
-	 * Get the services provided by the provider.
-	 *
-	 * @return array
-	 */
-	public function provides()
-	{
-		return array();
-	}
+            $this->app->make('cache')->extend('elasticache', function () use ($memcached) {
+                /** @noinspection PhpUndefinedNamespaceInspection */
+                /** @noinspection PhpUndefinedClassInspection */
+                return new \Illuminate\Cache\Repository(
+                    new \Illuminate\Cache\MemcachedStore($memcached, $this->app['config']->get('cache.prefix')));
+            });
+        }
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return [];
+    }
 
 }

--- a/src/Atyagi/Elasticache/ElasticacheSessionHandler.php
+++ b/src/Atyagi/Elasticache/ElasticacheSessionHandler.php
@@ -1,7 +1,5 @@
 <?php namespace Atyagi\Elasticache;
 
-use Illuminate\Support\Facades\App;
-use Memcached;
 use SessionHandlerInterface;
 
 class ElasticacheSessionHandler implements SessionHandlerInterface {
@@ -30,7 +28,7 @@ class ElasticacheSessionHandler implements SessionHandlerInterface {
      */
     public function open($savePath, $sessionName)
     {
-        if(!is_null($this->memcached)) {
+        if (!is_null($this->memcached)) {
             return true;
         }
         return false;
@@ -79,7 +77,7 @@ class ElasticacheSessionHandler implements SessionHandlerInterface {
     {
         $sessionId = $this->getSessionId($sessionId);
         $value = $this->memcached->get($sessionId);
-        if(empty($value)) {
+        if (empty($value)) {
             return $this->memcached->add($sessionId, $data, $this->sessionExpiry);
         } else {
             return $this->memcached->replace($sessionId, $data, $this->sessionExpiry);


### PR DESCRIPTION
This should prevent exceptions when the Memcached extension
is not loaded in the PHP runtime.